### PR TITLE
Fix group timeout exceeded param

### DIFF
--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -116,6 +116,9 @@ def main():
                        'render_color_path': 'Color/' + test['name'] + test['file_ext'],
                        'testcase_timeout': test['render_time']
                        })
+
+        if test_status == TEST_IGNORE_STATUS:
+            report.update({'group_timeout_exceeded': False})
         try:
             shutil.copyfile(
                 os.path.join(ROOT_DIR_PATH, 'jobs_launcher', 'common', 'img', report['test_status'] + test['file_ext']),


### PR DESCRIPTION
### Jira Ticket
* None
### Purpose
* Fix group timeout exceeded param
### Effect of change
* Set 'false' for group_timeout_exceeded param of skipped cases
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/RadeonProViewerManual/756/