### PR TITLE
fixed issue with animation for autorun

### DIFF
--- a/jobs/Tests/HDX_tests/test.cases.json
+++ b/jobs/Tests/HDX_tests/test.cases.json
@@ -9,6 +9,7 @@
         "config_parameters": {
             "file_ext": ".png",
             "animation": true,
+            "frames_per_second": 1,
             "render_quality": "medium",
             "engine": "hdx",
             "draw_engine": "d3d12",
@@ -39,6 +40,7 @@
         "config_parameters": {
             "file_ext": ".png",
             "animation": true,
+            "frames_per_second": 1,
             "render_quality": "medium",
             "engine": "hdx",
             "draw_engine": "d3d12",
@@ -69,6 +71,7 @@
         "config_parameters": {
             "file_ext": ".png",
             "animation": true,
+            "frames_per_second": 1,
             "render_quality": "medium",
             "engine": "hdx",
             "draw_engine": "d3d12",
@@ -99,6 +102,7 @@
         "config_parameters": {
             "file_ext": ".png",
             "animation": true,
+            "frames_per_second": 1,
             "render_quality": "medium",
             "engine": "hdx",
             "draw_engine": "d3d12",


### PR DESCRIPTION
### Jira Ticket

### Purpose
Animation didn't gave correct saved pictures for autotest report due to default 30fps pre-set (hdx test group)

### Effect of change
Added parameter "frames_per_second" for correct result in saved pictures for autotest report (hdx test group)

### ⚠️ Notes for Reviewers

### Related PR'S

### Jenkins Builds
Check run for 2080 and R7 Beta: 
https://rpr.cis.luxoft.com/view/RPR-Baikal/job/RadeonProViewerManual/850/Test_20Report/